### PR TITLE
Fixes Riptide Animation playing while player is driving an entity, and making crossbows with Flame over 5 work just like Flame 5.

### DIFF
--- a/essentials/items/magic/pickle_rocket.dsc
+++ b/essentials/items/magic/pickle_rocket.dsc
@@ -26,9 +26,12 @@ pickle_rocket_handler:
 
     on player right clicks block with:pickle_rocket:
       - determine passively cancelled
-      - inject pickle_launch
+      - inject pickle_launch if:!<player.is_inside_vehicle>
     on player damaged by fall flagged:behr.essentials.pickle_launched:
       - determine cancelled
+    # Prevention from riptide animation playing while player is mounted
+    on player enters entity:
+      - adjust <player> is_using_riptide:false
 
 pickle_launch:
   type: task

--- a/essentials/items/magic/pickle_rocket.dsc
+++ b/essentials/items/magic/pickle_rocket.dsc
@@ -30,7 +30,7 @@ pickle_rocket_handler:
     on player damaged by fall flagged:behr.essentials.pickle_launched:
       - determine cancelled
     # Prevention from riptide animation playing while player is mounted
-    on player enters entity:
+    on player enters entity flagged:behr.essentials.pickle_launched:
       - adjust <player> is_using_riptide:false
 
 pickle_launch:
@@ -45,5 +45,5 @@ pickle_launch:
     - adjust <player> is_using_riptide:true
     - wait 5t
     - waituntil <player.is_on_ground> || !<player.is_truthy>
-    - flag player behr.essentials.pickle_launched
+    - flag player behr.essentials.pickle_launched:!
     - adjust <player> is_using_riptide:false if:<player.is_truthy>

--- a/handlers/enchantments/flame.dsc
+++ b/handlers/enchantments/flame.dsc
@@ -18,7 +18,7 @@ new_enchantments:
       - if <[level]> == 4:
         - explode <[location]> power:1 source:<player>
 
-      - else if <[level]> >= 5:
+      - else if <[level]> == 5:
         - if !<player.has_flag[behr.essentials.combat.cooldown.large_flame_explosion]>:
           - flag <player> behr.essentials.combat.cooldown.large_flame_explosion expire:6s
           - explode <[location]> power:3 source:<player>

--- a/handlers/enchantments/flame.dsc
+++ b/handlers/enchantments/flame.dsc
@@ -18,7 +18,7 @@ new_enchantments:
       - if <[level]> == 4:
         - explode <[location]> power:1 source:<player>
 
-      - else if <[level]> == 5:
+      - else if <[level]> >= 5:
         - if !<player.has_flag[behr.essentials.combat.cooldown.large_flame_explosion]>:
           - flag <player> behr.essentials.combat.cooldown.large_flame_explosion expire:6s
           - explode <[location]> power:3 source:<player>


### PR DESCRIPTION
Fixes Pickle Rocket Animation(Riptide) playing while player is mounted/riding an entity.
Make all crossbows enchantaments over 5 act like Flame 5.
+ Merging branch from main repo.